### PR TITLE
Fix set_var to not include var name in value

### DIFF
--- a/bashible
+++ b/bashible
@@ -389,7 +389,9 @@ result() {
 }
 
 set_var() {
-  eval "$1=\$*"
+  var=$1
+  shift
+  eval "$var=\$*"
 }
 
 toplevel() {


### PR DESCRIPTION
Hey, first off - cool project. I really like how simple and straightforward it is.

I was trying to convert some ansible to try it out, but there seems to be a bug with set_var - it puts the name of the variable in the value.

For example:
```
@ example
    - set_var foo bar
    - echo $foo
```

will set the value of $foo to "foo bar"
This is equivalent to `foo="foo bar"` instead of `foo=bar`
