### PR TITLE
use whole line matching for add_line

### DIFF
--- a/bashible.edit.bash
+++ b/bashible.edit.bash
@@ -6,7 +6,7 @@ add_line() {
   local line=$1
   local path=$2
   quiet head -n 1 "$path" || { print_error "add_line: can't read file '$path'"; return 1; }
-  if ! quiet grep -F "$line" "$path"; then
+  if ! quiet grep -Fx "$line" "$path"; then
     echo "$line" >> "$path" || { print_error "add_line: can't write to file '$path'"; return 1; }
   else
     print_info "already"


### PR DESCRIPTION
This fixes the add_line function to match on the whole line of the destination file.
I ran:
```
      - add_line "PasswordAuthentication no" /etc/ssh/sshd_config
```
but the grep call matched on the `# PasswordAuthentication no` line that was already in the file and didn't add anything