### PR TITLE
don't run shell expansion when printing task

### DIFF
--- a/bashible
+++ b/bashible
@@ -42,7 +42,7 @@ ble_print_block() {
 }
 
 ble_print_task() {
-  echo -e "\033[37m - "$*" \033[0m" >&2
+  echo -e "\033[37m - $* \033[0m" >&2
 }
 
 ble_print_fail() {


### PR DESCRIPTION
Hi I believe the $* in the print_task function should be inside the quotes so that the command doesn't get expanded

I had a task that looked roughly like this:
```
- echo "0 0 * * * root /usr/local/bin/check_updates.sh" > /etc/cron.daily
```
But the bashible output expanded the * characters into all of my ble scripts making the output very messy:

```
 update_check  install a cronjob for it 

 - echo -e 0 0 distro_test.ble mail.ble test.ble update_check.ble user_setup.ble distro_test.ble mail.ble test.ble update_check.ble user_setup.ble distro_test.ble mail.ble test.ble update_check.ble user_setup.ble root /usr/local/sbin/check-for-updates.sh
```